### PR TITLE
fix: CI/CD 에러 수정 3

### DIFF
--- a/.github/workflows/dev-ci-cd.yml
+++ b/.github/workflows/dev-ci-cd.yml
@@ -24,21 +24,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -51,15 +41,18 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build, tag, and push image to Amazon ECR
+      - name: Build and push Docker image for ARM64
         id: build-image
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   # 2. EC2에 배포
   deploy:

--- a/.github/workflows/dev-ci-cd.yml
+++ b/.github/workflows/dev-ci-cd.yml
@@ -44,12 +44,15 @@ jobs:
       - name: Build and push Docker image for ARM64
         id: build-image
         uses: docker/build-push-action@v5
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
         with:
           context: .
           push: true
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
-            ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest
+            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest
           platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## 📝 작업 내용
<!-- 작업한 내용을 작성해주세요 -->
- CI/CD 파이프라인 구축 과정(#8)에서 발생한 에러를 해결합니다.
- 주요 원인: 배포 환경(EC2 t4g, arm64)과 빌드 환경(GitHub Runner, amd64) 간의 CPU 아키텍처 불일치
- CI 파이프라인이 배포 서버와 호환되는 arm64 플랫폼용 Docker 이미지를 생성하도록 수정했습니다.
## ⚡ 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- Docker Buildx 도입: amd64 환경에서 arm64 이미지를 빌드하기 위해 `docker/build-push-action`을 적용했습니다.
- ARM64 타겟 빌드: 빌드 시 `platforms: linux/arm64` 옵션을 설정하였습니다.
- 이미지 태그 전략 개선: 기존 태그와 `:latest` 태그를 함께 사용하도록 변경했습니다.
## 📌 리뷰 포인트
<!-- PR 리뷰시 참고할 내용을 작성해주세요 -->

## 📋 체크리스트
- [x] ✍ PR 제목 규칙을 맞췄나요? (예: `feat: 기능1 추가`)
- [x] 📝 관련 이슈를 등록했나요?
- [x] ✅ 모든 테스트가 통과했나요?
- [x] 🏗 빌드가 정상적으로 완료되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - ARM64 용 Docker 이미지 빌드 및 배포 지원
  - SHA 기반 태그와 latest 를 포함한 다중 태그 제공

- Chores
  - CI/CD 파이프라인 정리 및 Buildx 기반 크로스아키텍처 빌드 도입
  - 빌드 캐시 활용으로 전체 빌드 효율성 개선
  - 배포 단계는 최신 빌드 산출물을 그대로 사용하도록 유지
<!-- end of auto-generated comment: release notes by coderabbit.ai -->