### PR TITLE
feat: DB 연동 및 JPA 설정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Database
+DB_URL=
+DB_USERNAME=
+DB_PASSWORD=

--- a/.github/workflows/dev-ci-cd.yml
+++ b/.github/workflows/dev-ci-cd.yml
@@ -64,6 +64,9 @@ jobs:
           IMAGE_URI: ${{ needs.build-and-push.outputs.image_uri }}
           ECR_REGISTRY: ${{ needs.build-and-push.outputs.registry }}
           HOST_PORT: 8080
+          DB_URL: ${{ secrets.DB_URL }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
         run: |
           set -euo pipefail # 스크립트 오류 발생 시 즉시 중단
 
@@ -85,7 +88,12 @@ jobs:
           fi
 
           # 4. 새 컨테이너 실행
-          docker run -d --name $CONTAINER_NAME -p $HOST_PORT:8080 --restart always -e SPRING_PROFILES_ACTIVE=dev $IMAGE_URI
+          docker run -d --name $CONTAINER_NAME -p $HOST_PORT:8080 --restart always \
+          -e SPRING_PROFILES_ACTIVE=dev \
+          -e DB_URL="$DB_URL" \
+          -e DB_USERNAME="$DB_USERNAME" \
+          -e DB_PASSWORD="$DB_PASSWORD" \
+          $IMAGE_URI
           echo "✅ New container started."
 
           # 5. 사용하지 않는 Docker 이미지 정리

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,9 +31,18 @@ dependencies {
     // Environment Variable (.env)
     implementation("io.github.cdimascio:dotenv-kotlin:6.5.1")
 
+    // Spring Data JPA
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    // MySQL Connector/J
+    runtimeOnly("com.mysql:mysql-connector-j")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // H2
+    testImplementation("com.h2database:h2")
 }
 
 kotlin { compilerOptions { freeCompilerArgs.addAll("-Xjsr305=strict") } }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,5 +5,9 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
   jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
     hibernate:
       ddl-auto: validate

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: validate

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: create

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,5 +5,9 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
   jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
     hibernate:
       ddl-auto: create

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,5 @@ spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local}
   jpa:
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
     open-in-view: false
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,9 @@ spring:
     name: eodigo
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local}
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+    open-in-view: false

--- a/src/test/kotlin/com/eodigo/EodigoApplicationTests.kt
+++ b/src/test/kotlin/com/eodigo/EodigoApplicationTests.kt
@@ -2,8 +2,10 @@ package com.eodigo
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 
 @SpringBootTest
+@ActiveProfiles("test")
 class EodigoApplicationTests {
 
     @Test fun contextLoads() {}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL
+    username: sa
+    password:
+
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop


### PR DESCRIPTION
## 📝 작업 내용
<!-- 작업한 내용을 작성해주세요 -->
- Spring Boot 애플리케이션이 데이터베이스와 통신할 수 있도록 JPA 및 MySQL, H2 연동 설정을 했습니다.

## ⚡ 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- 의존성 추가
- CI/CD 파이프라인 수정: GitHub Secrets에 저장된 DB 접속 정보를 컨테이너 환경 변수로 주입하도록 수정
## 📌 리뷰 포인트
<!-- PR 리뷰시 참고할 내용을 작성해주세요 -->

## 📋 체크리스트
- [x] ✍ PR 제목 규칙을 맞췄나요? (예: `feat: 기능1 추가`)
- [x] 📝 관련 이슈를 등록했나요?
- [x] ✅ 모든 테스트가 통과했나요?
- [x] 🏗 빌드가 정상적으로 완료되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 작업(Chores)
  - 개발/로컬 프로필용 MySQL 데이터소스 환경변수 기반 설정 추가 및 스키마 정책(dev: validate, local: create)
  - 배포 파이프라인이 DB_URL/DB_USERNAME/DB_PASSWORD를 컨테이너에 전달하도록 업데이트
  - .env 예시에 DB 관련 자리표시자 추가
  - JPA 설정: SQL 로깅/포맷 활성화, Open-In-View 비활성화
  - 빌드 의존성에 Spring Data JPA 및 MySQL 드라이버 추가
- 테스트(Tests)
  - H2 데이터베이스를 테스트 의존성으로 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->