### PR TITLE
fix: 배치 예외 처리

### DIFF
--- a/src/main/kotlin/com/eodigo/batch/controller/BatchJobController.kt
+++ b/src/main/kotlin/com/eodigo/batch/controller/BatchJobController.kt
@@ -63,7 +63,7 @@ class BatchJobController(
 
             ResponseEntity.ok("Batch job '$jobName' has been started.")
         } catch (e: InvalidInputValueException) {
-            throw InvalidInputValueException()
+            throw e
         } catch (e: Exception) {
             ResponseEntity.internalServerError()
                 .body("Failed to start batch job '$jobName'. Reason: ${e.message}")

--- a/src/main/kotlin/com/eodigo/batch/controller/BatchJobController.kt
+++ b/src/main/kotlin/com/eodigo/batch/controller/BatchJobController.kt
@@ -1,11 +1,13 @@
 package com.eodigo.batch.controller
 
+import com.eodigo.common.exception.InvalidInputValueException
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.JobParametersBuilder
 import org.springframework.batch.core.launch.JobLauncher
@@ -15,6 +17,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "배치 API", description = "배치 잡 수동 실행용 API")
@@ -31,7 +34,10 @@ class BatchJobController(
     fun runBatchJob(
         @Parameter(description = "실행할 Job의 Bean 이름", example = "kamisDailyPriceSyncJob")
         @PathVariable
-        jobName: String
+        jobName: String,
+        @Parameter(description = "kamisDailyPriceSyncJob으로 조회할 날짜", example = "2025-08-22")
+        @RequestParam("surveyDate", required = false)
+        surveyDate: String?,
     ): ResponseEntity<String> {
         return try {
             val job = applicationContext.getBean(jobName, Job::class.java)
@@ -40,9 +46,14 @@ class BatchJobController(
                 JobParametersBuilder().addLocalDateTime("run.time", LocalDateTime.now())
 
             if (jobName == "kamisDailyPriceSyncJob") {
-                val surveyDate =
-                    LocalDate.now().minusDays(1).format(DateTimeFormatter.ISO_LOCAL_DATE)
-                jobParametersBuilder.addString("surveyDate", surveyDate)
+                val finalSurveyDate =
+                    when {
+                        surveyDate.isNullOrEmpty() ->
+                            LocalDate.now().minusDays(1).format(DateTimeFormatter.ISO_LOCAL_DATE)
+                        !isIsoLocalDate(surveyDate) -> throw InvalidInputValueException()
+                        else -> surveyDate
+                    }
+                jobParametersBuilder.addString("surveyDate", finalSurveyDate)
             }
 
             val jobParameters = jobParametersBuilder.toJobParameters()
@@ -53,6 +64,15 @@ class BatchJobController(
         } catch (e: Exception) {
             ResponseEntity.internalServerError()
                 .body("Failed to start batch job '$jobName'. Reason: ${e.message}")
+        }
+    }
+
+    fun isIsoLocalDate(dateString: String): Boolean {
+        return try {
+            LocalDate.parse(dateString)
+            true
+        } catch (e: DateTimeParseException) {
+            false
         }
     }
 }

--- a/src/main/kotlin/com/eodigo/batch/controller/BatchJobController.kt
+++ b/src/main/kotlin/com/eodigo/batch/controller/BatchJobController.kt
@@ -50,6 +50,7 @@ class BatchJobController(
                     when {
                         surveyDate.isNullOrEmpty() ->
                             LocalDate.now().minusDays(1).format(DateTimeFormatter.ISO_LOCAL_DATE)
+
                         !isIsoLocalDate(surveyDate) -> throw InvalidInputValueException()
                         else -> surveyDate
                     }
@@ -61,6 +62,8 @@ class BatchJobController(
             jobLauncher.run(job, jobParameters)
 
             ResponseEntity.ok("Batch job '$jobName' has been started.")
+        } catch (e: InvalidInputValueException) {
+            throw InvalidInputValueException()
         } catch (e: Exception) {
             ResponseEntity.internalServerError()
                 .body("Failed to start batch job '$jobName'. Reason: ${e.message}")

--- a/src/main/kotlin/com/eodigo/batch/processor/KamisDailyPriceProcessor.kt
+++ b/src/main/kotlin/com/eodigo/batch/processor/KamisDailyPriceProcessor.kt
@@ -33,6 +33,11 @@ class KamisDailyPriceProcessor(
     override fun process(wrapper: KamisDailyPriceApiData): DailyRegionalPrice? {
         // 2. 가격 정보가 유효하지 않으면 필터링
         val item = wrapper.item
+
+        if (item.rank != "상품") {
+            return null
+        }
+
         val priceStr = item.price?.replace(",", "")
         if (priceStr.isNullOrBlank() || priceStr == "-") {
             return null

--- a/src/main/kotlin/com/eodigo/common/exception/InvalidInputValueException.kt
+++ b/src/main/kotlin/com/eodigo/common/exception/InvalidInputValueException.kt
@@ -1,0 +1,3 @@
+package com.eodigo.common.exception
+
+class InvalidInputValueException : CustomException(ErrorCode.INVALID_INPUT_VALUE)


### PR DESCRIPTION
## 📝 작업 내용
<!-- 작업한 내용을 작성해주세요 -->
Spring Batch로 구현한 데이터 수집 잡을 수동으로 실행했을 때 발생하던 예외를 해결했습니다.(#22)
## ⚡ 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
```
2025-08-23T14:01:22.320Z ERROR 1 --- [eodigo] [nio-8080-exec-4] o.h.engine.jdbc.spi.SqlExceptionHelper   : Duplicate entry '18-1-2025-08-22-RETAIL' for key 'daily_regional_price.uk_daily_price_product_region_date_market'
```
- 원인: KAMIS API 응답에 동일한 품목/품종에 대해 품질 등급(rank)이 '상품'과 '중품'으로 나뉘어 포함되어 있었습니다. 이로 인해 Unique Key가 동일한 데이터가 하나의 Chunk에 포함되어 DB 저장 시 중복 키 예외가 발생했습니다.
```json
[
    ...
    {
        "item_name": "고구마",
        "item_code": "151",
        "kind_name": "밤(1kg)",
        "kind_code": "00",
        "rank": "상품",
        "rank_code": "04",
        "unit": "1kg",
        "day1": "당일 (08/22)",
        "dpr1": "5,370",
        ...
    },
    {
        "item_name": "고구마",
        "item_code": "151",
        "kind_name": "밤(1kg)",
        "kind_code": "00",
        "rank": "중품",
        "rank_code": "05",
        "unit": "1kg",
        "day1": "당일 (08/22)",
        "dpr1": "4,425",
        ...
    },
    ...
]
```

- 해결: KamisDailyPriceProcessor에 '상품' 등급(rank)의 데이터만 처리하고, 그 외 등급의 데이터는 필터링(null 반환)하는 로직을 추가하여 문제를 해결했습니다.
## 📌 리뷰 포인트
<!-- PR 리뷰시 참고할 내용을 작성해주세요 -->

## 📋 체크리스트
- [x] ✍ PR 제목 규칙을 맞췄나요? (예: `feat: 기능1 추가`)
- [x] 📝 관련 이슈를 등록했나요?
- [x] ✅ 모든 테스트가 통과했나요?
- [x] 🏗 빌드가 정상적으로 완료되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 배치 작업 실행 API가 선택적 surveyDate 쿼리 파라미터를 지원합니다. 미입력 시 어제 날짜를 기본으로 사용하고, ISO 로컬 날짜 형식이 아닌 값은 명확한 입력 오류 응답으로 처리됩니다.
- Bug Fixes
  - 일일 가격 처리에서 “상품”이 아닌 항목을 조기 필터링해 잘못된 데이터 수집·표시를 방지하고 처리 안정성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->