### PR TITLE
feat: API 키 인증 구현

### DIFF
--- a/.github/workflows/dev-ci-cd.yml
+++ b/.github/workflows/dev-ci-cd.yml
@@ -71,6 +71,7 @@ jobs:
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           KAMIS_API_KEY: ${{ secrets.KAMIS_API_KEY }}
           KAMIS_ID: ${{ secrets.KAMIS_ID }}
+          ADMIN_API_KEY: ${{secrets.ADMIN_API_KEY}}
         run: |
           set -euo pipefail # 스크립트 오류 발생 시 즉시 중단
 
@@ -99,6 +100,7 @@ jobs:
           -e DB_PASSWORD="$DB_PASSWORD" \
           -e KAMIS_API_KEY="$KAMIS_API_KEY" \
           -e KAMIS_ID="$KAMIS_ID" \
+          -e ADMIN_API_KEY="$ADMIN_API_KEY" \
           $IMAGE_URI
           echo "✅ New container started."
 

--- a/src/main/kotlin/com/eodigo/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/eodigo/common/exception/ErrorCode.kt
@@ -16,6 +16,7 @@ enum class ErrorCode(val status: HttpStatus, val code: String, val message: Stri
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "서버 내부에서 오류가 발생했습니다."),
     INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C004", "요청 값의 타입이 유효하지 않습니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "C005", "접근 권한이 없습니다."),
+    INVALID_API_KEY(HttpStatus.UNAUTHORIZED, "C006", "유효하지 않은 API 키입니다. 헤더(X-API-KEY)를 확인해주세요."),
 
     // Product
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "상품을 찾을 수 없습니다."),

--- a/src/main/kotlin/com/eodigo/common/exception/InvalidApiKeyException.kt
+++ b/src/main/kotlin/com/eodigo/common/exception/InvalidApiKeyException.kt
@@ -1,0 +1,3 @@
+package com.eodigo.common.exception
+
+class InvalidApiKeyException : CustomException(ErrorCode.INVALID_API_KEY)

--- a/src/main/kotlin/com/eodigo/common/interceptor/ApiKeyAuthInterceptor.kt
+++ b/src/main/kotlin/com/eodigo/common/interceptor/ApiKeyAuthInterceptor.kt
@@ -1,0 +1,30 @@
+package com.eodigo.common.interceptor
+
+import com.eodigo.common.exception.InvalidApiKeyException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+@Component
+class ApiKeyAuthInterceptor(@Value("\${admin.api-key}") private val serverApiKey: String) :
+    HandlerInterceptor {
+
+    companion object {
+        private const val API_KEY_HEADER_NAME = "X-API-KEY"
+    }
+
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+    ): Boolean {
+        val clientApiKey = request.getHeader(API_KEY_HEADER_NAME)
+
+        if (clientApiKey == null || clientApiKey != serverApiKey) {
+            throw InvalidApiKeyException()
+        }
+        return true
+    }
+}

--- a/src/main/kotlin/com/eodigo/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/eodigo/config/SwaggerConfig.kt
@@ -1,0 +1,39 @@
+package com.eodigo.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+    companion object {
+        const val API_KEY_SCHEME_NAME = "ApiKeyAuth"
+    }
+
+    private val apiKey: SecurityScheme =
+        SecurityScheme()
+            .type(SecurityScheme.Type.APIKEY)
+            .`in`(SecurityScheme.In.HEADER)
+            .name("X-API-KEY")
+            .description("배치 API 인증을 위한 API Key")
+
+    @Bean
+    fun openAPI(): OpenAPI {
+        val info: Info =
+            Info()
+                .title("어디고 API 명세서")
+                .description("오프라인 가격 비교 서비스 '어디고'의 API 명세서입니다.")
+                .version("v1.0")
+
+        val securityRequirement = SecurityRequirement().addList(API_KEY_SCHEME_NAME)
+
+        return OpenAPI()
+            .components(Components().addSecuritySchemes(API_KEY_SCHEME_NAME, apiKey))
+            .addSecurityItem(securityRequirement)
+            .info(info)
+    }
+}

--- a/src/main/kotlin/com/eodigo/config/WebConfig.kt
+++ b/src/main/kotlin/com/eodigo/config/WebConfig.kt
@@ -1,0 +1,14 @@
+package com.eodigo.config
+
+import com.eodigo.common.interceptor.ApiKeyAuthInterceptor
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig(private val apiKeyAuthInterceptor: ApiKeyAuthInterceptor) : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(apiKeyAuthInterceptor).addPathPatterns("/api/v1/batch/**")
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -31,3 +31,6 @@ kamis:
   api:
     key: ${KAMIS_API_KEY}
     cert-id: ${KAMIS_ID}
+
+admin:
+  api-key: default_api_key

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,6 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
   jpa:
     open-in-view: false
+
+admin:
+  api-key: ${ADMIN_API_KEY:default_api_key}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,4 +7,4 @@ spring:
     open-in-view: false
 
 admin:
-  api-key: ${ADMIN_API_KEY:default_api_key}
+  api-key: ${ADMIN_API_KEY}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -20,3 +20,6 @@ kamis:
   api:
     key: dummy-key
     cert-id: dummy-id
+
+admin:
+  api-key: default_api_key


### PR DESCRIPTION
## 📝 작업 내용
<!-- 작업한 내용을 작성해주세요 -->
배치 잡 실행 API에 대한 무분별한 접근을 제어하고자 API 키 기반의 인증 기능을 구현했습니다.
## ⚡ 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- API 키 인증 인터셉터 구현
- API 키 관리
  - 개발 환경에서는 Github Secrets에 추가한 환경변수를 사용합니다.
  - 로컬 환경에서는 기본 키(`default_api_key`)를 사용합니다. 별도의 환경변수 설정이 불필요합니다.
- Swagger API 문서 연동
## 📌 리뷰 포인트
<!-- PR 리뷰시 참고할 내용을 작성해주세요 -->

## 📋 체크리스트
- [x] ✍ PR 제목 규칙을 맞췄나요? (예: `feat: 기능1 추가`)
- [x] 📝 관련 이슈를 등록했나요?
- [x] ✅ 모든 테스트가 통과했나요?
- [x] 🏗 빌드가 정상적으로 완료되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - API 키 기반 인증을 도입해 지정된 배치 API 경로를 보호합니다.
  - 잘못된 또는 누락된 키 요청에 대해 401 응답과 안내 메시지를 반환합니다.
- **문서**
  - Swagger/OpenAPI에 X-API-KEY 보안 스킴을 추가하고 전역 보안 요구사항 및 API 명세(제목/설명/버전)를 설정했습니다.
- **Chores**
  - CI/CD에서 ADMIN_API_KEY를 컨테이너로 안전하게 전달하도록 구성했으며, 애플리케이션 설정에 환경변수 기반 admin.api-key를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->