### PR TITLE
refactor: 동일 가게 내 중복 메뉴 검색 시 최저가 메뉴만 반환하도록 수정

### DIFF
--- a/src/main/kotlin/com/eodigo/domain/restaurant/controller/StoreController.kt
+++ b/src/main/kotlin/com/eodigo/domain/restaurant/controller/StoreController.kt
@@ -1,20 +1,35 @@
 package com.eodigo.domain.restaurant.controller
 
+import com.eodigo.common.exception.ErrorResponse
 import com.eodigo.domain.restaurant.dto.SearchRequest
 import com.eodigo.domain.restaurant.dto.StoreDetailDto
 import com.eodigo.domain.restaurant.dto.StoreDto
 import com.eodigo.domain.restaurant.service.StoreService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 
+@Tag(name = "외식 API", description = "외식 정보 관련 API")
 @RestController
 @RequestMapping("/api/v1/stores")
 @Validated
 class StoreController(private val storeService: StoreService) {
 
-    /** 메뉴명, 위치, 지도 경계 등을 기반으로 매장 리스트를 검색 */
+    @Operation(
+        summary = "위치 기반 메뉴 최저가 매장 리스트 검색",
+        description = "메뉴명, 위치, 지도 경계 등을 기반으로 최저가 매장 리스트를 검색합니다.",
+    )
+    @ApiResponses(
+        value = [ApiResponse(responseCode = "200", description = "해당 메뉴 최저가 매장 리스트 조회 성공")]
+    )
     @GetMapping("/search")
     fun searchStores(
         @Valid @ModelAttribute request: SearchRequest
@@ -23,7 +38,32 @@ class StoreController(private val storeService: StoreService) {
         return ResponseEntity.ok(stores)
     }
 
-    /** 매장 상세 정보 조회 */
+    @Operation(summary = "매장 상세 정보 조회", description = "해당 ID의 매장의 상세 정보를 조회합니다.")
+    @ApiResponses(
+        value =
+            [
+                ApiResponse(responseCode = "200", description = "해당 ID의 매장 상세 정보 조회 성공"),
+                ApiResponse(
+                    responseCode = "404",
+                    description = "해당 정보 없음",
+                    content =
+                        [
+                            Content(
+                                schema = Schema(implementation = ErrorResponse::class),
+                                examples =
+                                    [
+                                        ExampleObject(
+                                            name = "Store Not Found",
+                                            description = "존재하지 않는 매장 ID",
+                                            value =
+                                                "{\"status\": 404, \"code\": \"S001\", \"message\": \"해당 매장을 찾을 수 없습니다.\"}",
+                                        )
+                                    ],
+                            )
+                        ],
+                ),
+            ]
+    )
     @GetMapping("/{storeId}")
     fun getStoreDetails(
         @Valid @PathVariable storeId: Long,

--- a/src/main/kotlin/com/eodigo/domain/restaurant/service/StoreService.kt
+++ b/src/main/kotlin/com/eodigo/domain/restaurant/service/StoreService.kt
@@ -33,9 +33,10 @@ class StoreService(
         val cheapestMenuByStore =
             menus
                 .groupBy { it.store }
-                .mapValues { (_, menusInStore) -> menusInStore.minByOrNull { it.price } }
-                .filterValues { it != null }
-                .map { it.key to it.value!! }
+                .mapNotNull { (store, menusInStore) ->
+                    val cheapestMenu = menusInStore.minByOrNull { it.price }
+                    cheapestMenu?.let { store to it }
+                }
 
         // 지도 경계값 내의 매장 필터링
         val locationFilteredMenus =

--- a/src/main/kotlin/com/eodigo/domain/restaurant/service/StoreService.kt
+++ b/src/main/kotlin/com/eodigo/domain/restaurant/service/StoreService.kt
@@ -29,10 +29,17 @@ class StoreService(
                 it.store.category == request.category
             }
 
+        // 가게별로 그룹화한 뒤, 각 가게에서 가장 저렴한 메뉴 하나만 선택
+        val cheapestMenuByStore =
+            menus
+                .groupBy { it.store }
+                .mapValues { (_, menusInStore) -> menusInStore.minByOrNull { it.price } }
+                .filterValues { it != null }
+                .map { it.key to it.value!! }
+
         // 지도 경계값 내의 매장 필터링
         val locationFilteredMenus =
-            menus.filter { menu ->
-                val store = menu.store
+            cheapestMenuByStore.filter { (store, _) ->
                 store.latitude >= request.southWestLat &&
                     store.latitude <= request.northEastLat &&
                     store.longitude >= request.southWestLng &&
@@ -40,8 +47,7 @@ class StoreService(
             }
 
         val storeDtoList =
-            locationFilteredMenus.map { menu ->
-                val store = menu.store
+            locationFilteredMenus.map { (store, menu) ->
                 val distance =
                     calculateDistance(
                         lat1 = request.userLat,


### PR DESCRIPTION
## 📝 작업 내용
메뉴 검색 API(GET /api/v1/stores/search)의 응답 결과 개선
동일한 가게 내에서는 검색 키워드와 일치하는 메뉴 중 가장 저렴한 메뉴 하나만을 대표로 반환하도록 로직 변경

## ⚡ 주요 변경사항
StoreService의 searchStores 메서드 로직 수정
  - 조회된 메뉴 리스트를 store 기준으로 groupBy하여 가게별로 그룹화
  - 각 가게 그룹 내에서 minByOrNull을 사용해 가격이 가장 낮은 메뉴를 선택
  - 최종적으로 각 가게별 최저가 메뉴 하나만을 기준으로 위치 필터링 및 정렬을 수행하여 반환

## 📌 리뷰 포인트
<!-- PR 리뷰시 참고할 내용을 작성해주세요 -->

## 📋 체크리스트
- [x] ✍ PR 제목 규칙을 맞췄나요? (예: `feat: 기능1 추가`)
- [x] 📝 관련 이슈를 등록했나요?
- [x] ✅ 모든 테스트가 통과했나요?
- [x] 🏗 빌드가 정상적으로 완료되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 검색 결과가 매장당 1건으로 정리되어 중복 노출을 방지하고, 각 매장의 최저가 메뉴 기준으로 표시됩니다.
  - 지도 경계 내에 위치한 매장만 결과로 반환되며, 거리 계산과 정렬 로직은 동일하게 유지됩니다.

- 문서
  - 외식 API 문서 개선: 엔드포인트 요약/설명 추가 및 응답 명세 강화(200, 404).
  - 404 응답에 에러 스키마와 예시 페이로드를 추가하여 오류 상황을 명확히 안내합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->