### PR TITLE
feat: Prometheus 연동을 위한 Actuator 설정 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,9 @@ dependencies {
     // Jackson
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
+    // Prometheus
+    implementation("io.micrometer:micrometer-registry-prometheus")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -30,3 +30,14 @@ sentry:
   traces-sample-rate: 1.0
   send-default-pii: true
   enabled: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,prometheus"
+  server:
+    port: 9000
+  metrics:
+    tags:
+      application: ${spring.application.name}


### PR DESCRIPTION
## 📝 작업 내용
<!-- 작업한 내용을 작성해주세요 -->
모니터링 시스템(Prometheus)이 서버의 애플리케이션 지표(JVM, Spring Boot)를 수집할 수 있도록 Actuator 설정을 추가하고 관련 의존성을 설정했습니다.

## ⚡ 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- `build.gradle.kts`: `micrometer-registry-prometheus` 의존성을 추가했습니다.
- `application-dev.yml`: Actuator의 `prometheus` 엔드포인트를 9000번 포트로 노출시키는 설정을 추가했습니다.

## 📌 리뷰 포인트
<!-- PR 리뷰시 참고할 내용을 작성해주세요 -->

## 📋 체크리스트
- [x] ✍ PR 제목 규칙을 맞췄나요? (예: `feat: 기능1 추가`)
- [x] 📝 관련 이슈를 등록했나요?
- [x] ✅ 모든 테스트가 통과했나요?
- [x] 🏗 빌드가 정상적으로 완료되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 애플리케이션 모니터링 및 메트릭 수집 기능이 추가되었습니다.
* 헬스 체크 엔드포인트를 통해 애플리케이션 상태를 확인할 수 있습니다.
* Prometheus 메트릭 수집을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->