### PR TITLE
fix: 헬스체크 경로 수정

### DIFF
--- a/.github/workflows/dev-ci-cd.yml
+++ b/.github/workflows/dev-ci-cd.yml
@@ -98,6 +98,7 @@ jobs:
 
           # 4. 새 컨테이너 실행
           docker run -d --name $CONTAINER_NAME -p $HOST_PORT:8080 --restart always \
+          -p $ACTUATOR_PORT:9000 \
           -e SPRING_PROFILES_ACTIVE=dev \
           -e DB_URL="$DB_URL" \
           -e DB_USERNAME="$DB_USERNAME" \

--- a/.github/workflows/dev-ci-cd.yml
+++ b/.github/workflows/dev-ci-cd.yml
@@ -75,6 +75,7 @@ jobs:
           KAMIS_ID: ${{ secrets.KAMIS_ID }}
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          ACTUATOR_PORT: 9000
         run: |
           set -euo pipefail # 스크립트 오류 발생 시 즉시 중단
 
@@ -116,7 +117,7 @@ jobs:
           echo "Waiting for application health check..."
           sleep 15
           for i in {1..12}; do
-            response=$(curl --max-time 5 -s -o /dev/null -w '%{http_code}' http://localhost:$HOST_PORT/actuator/health || true)
+            response=$(curl --max-time 5 -s -o /dev/null -w '%{http_code}' http://localhost:$ACTUATOR_PORT/actuator/health || true)
             if [ "$response" = "200" ]; then
               echo "🚀 Health check PASSED. Deployment successful!"
               exit 0

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -30,14 +30,3 @@ sentry:
   traces-sample-rate: 1.0
   send-default-pii: true
   enabled: true
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: "health,prometheus"
-  server:
-    port: 9000
-  metrics:
-    tags:
-      application: ${spring.application.name}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,14 @@ spring:
 
 admin:
   api-key: ${ADMIN_API_KEY}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,prometheus"
+  server:
+    port: 9000
+  metrics:
+    tags:
+      application: ${spring.application.name}


### PR DESCRIPTION
## 📝 작업 내용
<!-- 작업한 내용을 작성해주세요 -->
Actuator의 관리 포트를 API 포트와 분리(`9000`)함에 따라, CI/CD 워크플로우의 Docker 헬스체크가 실패하던 문제를 해결했습니다.
헬스체크 요청이 새로운 Actuator 포트를 올바르게 바라보도록 수정하였고, 이와 함께 관련 설정의 위치를 `dev` 프로파일에서 공통 프로파일로 이동하여 코드 중복 문제를 개선했습니다.

## ⚡ 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
-   `dev-ci-cd.yml`: 헬스체크 요청 URL의 포트를 기존 API 포트에서 Actuator 전용 포트(`9000`)로 변경하여 배포 실패 오류를 수정했습니다.

## 📌 리뷰 포인트
<!-- PR 리뷰시 참고할 내용을 작성해주세요 -->

## 📋 체크리스트
- [x] ✍ PR 제목 규칙을 맞췄나요? (예: `feat: 기능1 추가`)
- [x] 📝 관련 이슈를 등록했나요?
- [x] ✅ 모든 테스트가 통과했나요?
- [x] 🏗 빌드가 정상적으로 완료되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기타**
  * 배포 작업에서 헬스 체크 포트를 새 환경변수(ACTUATOR_PORT=9000)로 분리하고 컨테이너 포트 매핑을 추가
  * 관리(관리자) 엔드포인트(health, prometheus) 노출 및 관리 포트(9000) 설정 추가
  * 개발 환경 설정에서 관리 관련 블록 정리(불필요한 관리 설정 제거)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->